### PR TITLE
Improve navigation header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,9 +24,10 @@ import HeaderLink from "./HeaderLink.astro";
   nav ul {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     justify-content: flex-start;
     align-items: center;
-    gap: 1rem 2rem;
+    gap: 0.2rem 2rem;
     list-style: none;
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -26,7 +26,7 @@ import HeaderLink from "./HeaderLink.astro";
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;
-    gap: 2rem;
+    gap: 1rem 2rem;
     list-style: none;
   }
 </style>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -49,6 +49,11 @@ if (logo) {
     text-decoration: none;
   }
 
+  li {
+    display: inline-block;
+    white-space: nowrap;
+  }
+
   li:not(:last-child)::after {
     content: "";
     display: inline-block;


### PR DESCRIPTION
This prevents the ::after pseudo-element from wrapping in mobile views. It still doesn't let the whole mobile navigation wrap though.